### PR TITLE
로컬 푸시 알림 구현

### DIFF
--- a/AnkiCloneApp/Controllers/HomeViewController.swift
+++ b/AnkiCloneApp/Controllers/HomeViewController.swift
@@ -16,6 +16,9 @@ struct CellTappedEvent: EventProtocol {
 final class HomeViewController: RootViewController<HomeView> {
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        SettingService.shared.requestNotificationAuthorization()
+        SettingService.shared.sendTestNoti()
 
         EventBus.shared.on(PushToSettingScreenEvent.self, by: self) { listener, _ in
             listener.navigationController?.pushViewController(SettingViewController(), animated: true)

--- a/AnkiCloneApp/Controllers/HomeViewController.swift
+++ b/AnkiCloneApp/Controllers/HomeViewController.swift
@@ -17,9 +17,8 @@ final class HomeViewController: RootViewController<HomeView> {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        SettingService.shared.requestNotificationAuthorization()
-        SettingService.shared.sendTestNoti()
-
+        SettingService.shared.requestNotificationAuthorization() // 푸시알림 권한요청
+        
         EventBus.shared.on(PushToSettingScreenEvent.self, by: self) { listener, _ in
             listener.navigationController?.pushViewController(SettingViewController(), animated: true)
         }

--- a/AnkiCloneApp/Controllers/SettingViewController.swift
+++ b/AnkiCloneApp/Controllers/SettingViewController.swift
@@ -33,6 +33,7 @@ final class SettingViewController: RootViewController<SettingView> {
         
         EventBus.shared.on(SwitchValueChangedEvent.self, by: self) { listener, payload in
             listener.handleSwitchValueChanged(payload)
+            SettingService.shared.sendTestNoti() // false로 변경했을 때 앱 내 알림 안보이는것 테스트
         }
     }
     

--- a/AnkiCloneApp/Controllers/SettingViewController.swift
+++ b/AnkiCloneApp/Controllers/SettingViewController.swift
@@ -33,7 +33,6 @@ final class SettingViewController: RootViewController<SettingView> {
         
         EventBus.shared.on(SwitchValueChangedEvent.self, by: self) { listener, payload in
             listener.handleSwitchValueChanged(payload)
-            SettingService.shared.sendTestNoti() // false로 변경했을 때 앱 내 알림 안보이는것 테스트
         }
     }
     
@@ -76,5 +75,6 @@ final class SettingViewController: RootViewController<SettingView> {
     
     private func handleSwitchValueChanged(_ isOn: Bool) {
         SettingService.shared.updateIsShowInAppNotifications(isOn)
+        SettingService.shared.sendTestNoti() // true로 변경했을 때 앱 내 알림 보이는것 테스트
     }
 }

--- a/AnkiCloneApp/Resources/AppDelegate.swift
+++ b/AnkiCloneApp/Resources/AppDelegate.swift
@@ -1,10 +1,26 @@
 import CoreData
 import UIKit
+import UserNotifications
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        
         return true
+    }
+    
+    // Foreground 상태 푸시알림
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        if SettingService.shared.setting.isShowInAppNotifications {
+            completionHandler([.banner, .sound, .badge])
+        }
+    }
+    
+    // Background 또는 앱 종료 상태 푸시알림
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+
+        completionHandler()
     }
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {

--- a/AnkiCloneApp/Services/SettingService.swift
+++ b/AnkiCloneApp/Services/SettingService.swift
@@ -1,32 +1,33 @@
 import Foundation
+import UserNotifications
 
 final class SettingService {
     static let shared: SettingService = .init()
     private init() {}
-
+    
     private lazy var key: String = .init(describing: self)
     var storage: Storage? { didSet { setting = load() ?? setting }}
-    private(set) var setting: SettingViewModel = .init(notificationOption: .none, reminderTime: Date(), isShowInAppNotifications: true)
-
+    private(set) var setting: SettingViewModel = .init(notificationOption: .everyday, reminderTime: Date(), isShowInAppNotifications: true)
+    
     func updateNotificationOption(_ newOption: NotificationOption) {
         let newSetting = setting
-
+        
         newSetting.notificationOption = newOption
         setting = newSetting
         save(setting: newSetting)
     }
-
+    
     func updateReminderTime(_ newOption: Date) {
         let newSetting = setting
-
+        
         newSetting.reminderTime = newOption
         setting = newSetting
         save(setting: newSetting)
     }
-
+    
     func updateIsShowInAppNotifications(_ newOption: Bool) {
         let newSetting = setting
-
+        
         newSetting.isShowInAppNotifications = newOption
         setting = newSetting
         save(setting: newSetting)
@@ -37,9 +38,62 @@ extension SettingService {
     private func save(setting: SettingViewModel) {
         storage?.save(setting.toModel(), forKey: key)
     }
-
+    
     private func load() -> SettingViewModel? {
         guard let model: SettingModel = storage?.load(forKey: key) else { return nil }
         return model.toViewModel()
+    }
+}
+
+// UserNotifications 관련
+extension SettingService {
+    func requestNotificationAuthorization() {
+        let authOptions: UNAuthorizationOptions = [.alert, .sound, .badge]
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { (granted, error) in
+            if granted {
+                print("알림 권한이 허용됨")
+            } else {
+                print("알림 권한이 거부됨")
+            }
+        }
+    }
+    
+    private func cancelDailyNotification() {
+        let notificationCenter = UNUserNotificationCenter.current()
+        
+        notificationCenter.removeAllPendingNotificationRequests()
+    }
+    
+    func sendTestNoti() {
+        let notificationCenter = UNUserNotificationCenter.current()
+        
+        notificationCenter.removeAllPendingNotificationRequests()
+        
+        // 1. 알림 내용 작성 -> content
+        let content = UNMutableNotificationContent()
+        content.title = "오늘도 Anki와 함께 공부해봐요!"
+        content.body = "터치하면 앱의 메인 화면으로 이동합니다."
+        
+        // 2. 발동조건 작성 -> trigger
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+        //let trigger = UNCalendarNotificationTrigger(dateMatching: Calendar.current.dateComponents([.hour, .minute], from: setting.reminderTime), repeats: true)
+        
+        // 3. 요청 작성 -> request
+        let request = UNNotificationRequest(
+            identifier: "testNotification",
+            content: content,
+            trigger: trigger
+        )
+        
+        if setting.notificationOption != .none {
+            notificationCenter.add(request) { (error) in
+                if let error = error {
+                    print("sendTestNoti: 실패 \(error.localizedDescription)")
+                } else {
+                    print("sendTestNoti: 성공")
+                }
+            }
+        }
     }
 }

--- a/AnkiCloneApp/Views/SettingView/SettingView.swift
+++ b/AnkiCloneApp/Views/SettingView/SettingView.swift
@@ -89,6 +89,7 @@ extension SettingView: UITableViewDataSource {
                 let switchView = UISwitch()
                 
                 config.text = setting?.showInAppNotificationsTitle
+                switchView.isOn = setting?.isShowInAppNotifications ?? true
                 cell.accessoryView = switchView
                 
                 switchView.addTarget(self, action: #selector(switchValueChanged(_:)), for: .valueChanged)

--- a/AnkiCloneApp/Views/SettingView/SettingView.swift
+++ b/AnkiCloneApp/Views/SettingView/SettingView.swift
@@ -89,7 +89,7 @@ extension SettingView: UITableViewDataSource {
                 let switchView = UISwitch()
                 
                 config.text = setting?.showInAppNotificationsTitle
-                switchView.isOn = setting?.isShowInAppNotifications ?? true
+                switchView.isOn = setting?.isShowInAppNotifications ?? false
                 cell.accessoryView = switchView
                 
                 switchView.addTarget(self, action: #selector(switchValueChanged(_:)), for: .valueChanged)


### PR DESCRIPTION
### 로컬 푸시 알림
**SettingService**
  - setUserNotificationSettings() 작성 
    - notificationOption에 따라 notificationCenter에 각각 다른 noti 세팅
    - notificationOption을 @Publishable로 구독해, 값이 변경될 때 setupPublishing() 호출
- 권한 허용 함수 작성
  - 호출은 HomeViewController
- 시연용 테스트 푸시알림 함수 작성
  - 설정 -> 앱 내 알림 표시 true로 토글 3초 후 요청
  - foreground, background, 앱 종료 상태에서도 동작하도록 `AppDelegate.swift` 수정

<img width="300" alt="image" src="https://github.com/nbcamp/anki-clone-app/assets/37580034/346ec112-ddcd-41b3-a349-2b6afcb42b15">
